### PR TITLE
Fix exit on docker image start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,4 +108,3 @@ venv.bak/
 
 .vscode
 Dockerfile
-watch-folder


### PR DESCRIPTION
add default folder to be as volume mount location when docker container starts

Resolves: [Bugfix] no default watch-folder provided