### PR TITLE
fix issue where default log level was not being used

### DIFF
--- a/app/FolderWatcher.py
+++ b/app/FolderWatcher.py
@@ -11,7 +11,7 @@ from sys import exit
 class FolderWatcher:
 
     def __init__(self, event_groups):
-        self.logger = Logger(APP_CONFIG['LOGGING_CONFIG']['LOG_LOCATION'], name=__name__)
+        self.logger = Logger(APP_CONFIG['LOGGING_CONFIG']['LOG_LOCATION'], loglevel=APP_CONFIG['LOGGING_CONFIG']['DEFAULT_LOG_LEVEL'], name=__name__)
         self.logger.log.info("Watcher initializing")
         self.__event_handler_groups = self.__create_event_handlers(event_groups)
         self.__event_observer = Observer()

--- a/app/Logger.py
+++ b/app/Logger.py
@@ -1,5 +1,6 @@
 import logging
 
+
 class Logger:
 
     def __init__(self, folder, name = __name__, loglevel=logging.INFO, loggingtype=2, format = "%(levelname)s:%(asctime)s:%(name)s:%(funcName)s:%(message)s"):

--- a/app/events/EmailProcessor.py
+++ b/app/events/EmailProcessor.py
@@ -8,7 +8,7 @@ from ..utils.file_manager import read_json_file
 class EmailProcessor(FileEventHandler):
 
     def __init__(self, email_data_location, FILE_EXTS=None):
-        self.logger = Logger(APP_CONFIG['LOGGING_CONFIG']['LOG_LOCATION'], name=__name__)
+        self.logger = Logger(APP_CONFIG['LOGGING_CONFIG']['LOG_LOCATION'], loglevel=APP_CONFIG['LOGGING_CONFIG']['DEFAULT_LOG_LEVEL'], name=__name__)
         self.logger.log.info("DefaultFileHandler initializing")
         
         if FILE_EXTS is not None:

--- a/app/events/FileEventHandler.py
+++ b/app/events/FileEventHandler.py
@@ -1,6 +1,6 @@
 from os.path import getsize
 from time import sleep
-from abc import ABC, abstractclassmethod
+from abc import ABC, abstractmethod
 from re import compile, I
 from ..Logger import Logger
 from app import APP_CONFIG
@@ -45,5 +45,5 @@ class FileEventHandler(RegexMatchingEventHandler, ABC):
     def __is_list(self, obj):
         return type(obj) == list
         
-    @abstractclassmethod
+    @abstractmethod
     def process(self, event):pass

--- a/app/events/FileEventHandler.py
+++ b/app/events/FileEventHandler.py
@@ -7,6 +7,7 @@ from app import APP_CONFIG
 
 from watchdog.events import RegexMatchingEventHandler
 
+
 class FileEventHandler(RegexMatchingEventHandler, ABC):
 
     def __init__(self, FILE_EXTS = [r".*"]):

--- a/app/events/FileEventHandler.py
+++ b/app/events/FileEventHandler.py
@@ -10,7 +10,7 @@ from watchdog.events import RegexMatchingEventHandler
 class FileEventHandler(RegexMatchingEventHandler, ABC):
 
     def __init__(self, FILE_EXTS = [r".*"]):
-        self.logger = Logger(APP_CONFIG['LOGGING_CONFIG']['LOG_LOCATION'], name=__name__)
+        self.logger = Logger(APP_CONFIG['LOGGING_CONFIG']['LOG_LOCATION'], loglevel=APP_CONFIG['LOGGING_CONFIG']['DEFAULT_LOG_LEVEL'], name=__name__)
 
         if not self.__is_list(FILE_EXTS):
             raise TypeError("TypeError: {} is of type {}, not list".format(FILE_EXTS, type(FILE_EXTS)))


### PR DESCRIPTION
Fix issue where default log level was not being used. Add default log level to the custom logger class initialization

Also fixed formatting in some classes and replaced ```abstractclassmethod``` annotation for ```abstractmethod``` annotation